### PR TITLE
Suggestion:  move some of the compose logic into the extension modules

### DIFF
--- a/src/Pagination.ts
+++ b/src/Pagination.ts
@@ -1,4 +1,5 @@
-import { AspectAdvice } from 'dojo-compose/compose';
+import compose, { AspectAdvice, ComposeFactory } from 'dojo-compose/compose';
+
 export class Pagination {
 	rowsPerPage: number;
 	pageNumber: number;
@@ -52,4 +53,8 @@ export const paginationAdvice: AspectAdvice = {
 export function paginationInit(options: { [index: string ]: any }) {
 	this.rowsPerPage = options['rowsPerPage'];
 	this.pageNumber = options['pageNumber']
+}
+
+export function paginationFactory<O, A>(factory: ComposeFactory<O, A>): ComposeFactory<O, A & Pagination> {
+	return compose.mixin(factory, compose(Pagination, paginationInit)).aspect(paginationAdvice)
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,5 @@
 import { List, ListInit } from './List';
-import { Pagination, paginationAdvice, paginationInit } from './Pagination';
+import { paginationFactory } from './Pagination';
 import { Editor, editorInit, editorAdvice } from './Editor';
 import { Decorator, decoratorInit, decoratorAdvice } from './Decorator';
 import compose from 'dojo-compose/compose';
@@ -11,11 +11,9 @@ const columns: {name: string, field: string}[] = [
 ];
 
 const listFactory = compose(List, ListInit);
-const paginatedListFactory = compose(List, ListInit).mixin(compose(Pagination, paginationInit)).aspect(paginationAdvice);
+const paginatedListFactory = paginationFactory(compose(List, ListInit));
 const EditorList = compose(List, ListInit).mixin(compose(Editor, editorInit)).aspect(editorAdvice);
-const paginatedEditorDecoratorListFactory = compose(List, ListInit)
-	.mixin(compose(Pagination, paginationInit))
-	.aspect(paginationAdvice)
+const paginatedEditorDecoratorListFactory = paginationFactory(compose(List, ListInit))
 	.mixin(compose(Editor, editorInit))
 	.aspect(editorAdvice)
 	.mixin(compose(Decorator, decoratorInit))

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,7 @@
 		"./_modules/**/*.d.ts"
 	],
 	"files": [
+		"./src/Decorator.ts",
 		"./src/Editor.ts",
 		"./src/List.ts",
 		"./src/Pagination.ts",


### PR DESCRIPTION
Looking at the code in main.ts, two things are apparent:
1.  I need to really know how dojo-compose works.
2.  I really need to know how these extension modules weave themselves into the base classes.

I created the `Pagination/paginationFactory` function so I could move the mixin and aspect calls into the Pagination module.  Maybe now a dev using the Pagination modules only needs to know how the basic `compose.create()` works because the business of applying advices is now hidden.  This reduces #1 above and eliminates #2.

Maybe the  `Pagination/paginationFactory` function could also take an ES6 class.

My thought is we, the dgrid devs, can write the complicated compose code and make dgrid extensions easier to use.  

With my idea, applying multiple extensions would mean nesting function calls.  Could we change compose to make  something like this work?

``` javascript
const myGridFactory = compose(OnDemandGrid).add(AColumnSetExtension).add(AKeyboardExtension);
```

I just picked `add` as a name.  It could be anything, but this `add` method would allow the extensions to make as many other compose/mixin/aspect calls as needed.  Similar to my new `paginationFactory` function in this PR.
